### PR TITLE
fix: Correct regexp gives InvalidArgumentException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
             "email": "jmcustiel@gmail.com",
             "homepage": "https://github.com/mcustiel",
             "role": "Developer"
+        },
+        {
+            "name": "Sergey Gripinskiy",
+            "email": "web-architect@mail.ru",
+            "role": "Contributor"
         }
     ],
     "name" : "mcustiel/phiremock-common",

--- a/src/Domain/Condition/Pattern.php
+++ b/src/Domain/Condition/Pattern.php
@@ -30,8 +30,14 @@ class Pattern extends ConditionValue
 
     private function assertRegex(string $pattern): void
     {
-        if ($pattern[0] !== $pattern[\strlen($pattern) - 1]) {
-            throw new InvalidArgumentException(sprintf('Invalid regular expression received: %s', $pattern));
+        /**
+         * The only sane way to validate a regexp is to execute it.
+         * Possible warnings or notices are suppressed.
+         */
+        if (false === @preg_match($pattern, null)) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid regular expression received: `%s`, preg error #%d', $pattern, preg_last_error())
+            );
         }
     }
 }

--- a/tests/unit/Domain/Condition/PatternTest.php
+++ b/tests/unit/Domain/Condition/PatternTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Mcustiel\Phiremock\Tests\Unit\Domain\Condition;
+
+use InvalidArgumentException;
+use Mcustiel\Phiremock\Domain\Condition\Pattern;
+use PHPUnit\Framework\TestCase;
+
+class PatternTest extends TestCase
+{
+    /**
+     * @dataProvider correctPatternDataProvider
+     *
+     * @param string $regex
+     *
+     * @return void
+     */
+    public function testCorrectPattern(string $regex): void
+    {
+        $this->assertInstanceOf(
+            Pattern::class,
+            new Pattern($regex)
+        );
+    }
+
+    /**
+     * @return array<array<string, string>>
+     */
+    public function correctPatternDataProvider(): array
+    {
+        return [
+            'any_string_no_modifier'                 => ['/.*/'],
+            'any_string_with_modifier'               => ['/.*/i'],
+            'any_string_no_modifier_custom_escape'   => ['@.*@'],
+            'any_string_with_modifier_custom_escape' => ['@.*@i'],
+        ];
+    }
+
+    /**
+     * @dataProvider incorrectPatternDataProvider
+     *
+     * @param string $regex
+     *
+     * @return void
+     */
+    public function testIncorrectPattern(string $regex): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Pattern($regex);
+    }
+
+    /**
+     * @return array<array<string, string>>
+     */
+    public function incorrectPatternDataProvider(): array
+    {
+        return [
+            'empty'           => [''],
+            'no_closing_char' => ['/.*'],
+            'no_opening_char' => ['.*/'],
+        ];
+    }
+}


### PR DESCRIPTION
- Fixed: regular expression is now checked by executing it. Natural
  and the most sustainable way.