### PR TITLE
fix: Passing null $subject to preg_match is deprecated [PHP 8.1]

### DIFF
--- a/src/Domain/Condition/Pattern.php
+++ b/src/Domain/Condition/Pattern.php
@@ -34,7 +34,7 @@ class Pattern extends ConditionValue
          * The only sane way to validate a regexp is to execute it.
          * Possible warnings or notices are suppressed.
          */
-        if (false === @preg_match($pattern, null)) {
+        if (false === @preg_match($pattern, '')) {
             throw new InvalidArgumentException(sprintf('Invalid regular expression received: `%s`, preg error #%d', $pattern, preg_last_error()));
         }
     }


### PR DESCRIPTION
This is deprecated in PHP 8.1 — [_Passing null to non-nullable parameters of built-in functions_](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal)