### PR TITLE
Added new JsonPath condition

### DIFF
--- a/src/Domain/Condition/Conditions/JsonPathCondition.php
+++ b/src/Domain/Condition/Conditions/JsonPathCondition.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mcustiel\Phiremock\Domain\Condition\Conditions;
+
+use Mcustiel\Phiremock\Domain\Condition\Condition;
+
+class JsonPathCondition extends Condition
+{
+}

--- a/src/Domain/Condition/Conditions/JsonPathConditionCollection.php
+++ b/src/Domain/Condition/Conditions/JsonPathConditionCollection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mcustiel\Phiremock\Domain\Condition\Conditions;
+
+use Mcustiel\Phiremock\Domain\AbstractArrayCollection;
+use Mcustiel\Phiremock\Domain\Http\JsonPathName;
+
+/** @method JsonPathCondition current() */
+final class JsonPathConditionCollection extends AbstractArrayCollection
+{
+    public function __toString()
+    {
+        $string = '';
+        /** @var JsonPathName $pathName */
+        /** @var JsonPathCondition $condition */
+        foreach ($this as $pathName => $condition) {
+            $string .= $pathName->asString() . ' => ' . $condition->__toString();
+        }
+        return $string;
+    }
+
+    public function setPathCondition(JsonPathName $path, JsonPathCondition $condition)
+    {
+        parent::set($path->asString(), $condition);
+    }
+
+    /** @return JsonPathName */
+    public function key()
+    {
+        return new JsonPathName(parent::key());
+    }
+
+    public function iterator()
+    {
+        return new JsonPathConditionIterator($this->array);
+    }
+}

--- a/src/Domain/Condition/Conditions/JsonPathConditionIterator.php
+++ b/src/Domain/Condition/Conditions/JsonPathConditionIterator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mcustiel\Phiremock\Domain\Condition\Conditions;
+
+use Mcustiel\Phiremock\Domain\AbstractArrayIterator;
+use Mcustiel\Phiremock\Domain\Http\JsonPathName;
+
+/** @method JsonPathCondition current() */
+final class JsonPathConditionIterator extends AbstractArrayIterator
+{
+    public function __toString()
+    {
+        $string = '';
+        /** @var JsonPathName $pathName */
+        /** @var JsonPathCondition $condition */
+        foreach ($this as $pathName => $condition) {
+            $string .= $pathName->asString() . ' => ' . $condition->__toString();
+        }
+        return $string;
+    }
+
+    /** @return JsonPathName */
+    public function key()
+    {
+        return new JsonPathName(parent::key());
+    }
+}

--- a/src/Domain/Conditions.php
+++ b/src/Domain/Conditions.php
@@ -21,6 +21,7 @@ namespace Mcustiel\Phiremock\Domain;
 use Mcustiel\Phiremock\Domain\Condition\Conditions\BodyCondition;
 use Mcustiel\Phiremock\Domain\Condition\Conditions\FormFieldConditionIterator;
 use Mcustiel\Phiremock\Domain\Condition\Conditions\HeaderConditionIterator;
+use Mcustiel\Phiremock\Domain\Condition\Conditions\JsonPathConditionIterator;
 use Mcustiel\Phiremock\Domain\Condition\Conditions\MethodCondition;
 use Mcustiel\Phiremock\Domain\Condition\Conditions\UrlCondition;
 use Mcustiel\Phiremock\Domain\Options\ScenarioState;
@@ -39,6 +40,8 @@ class Conditions
     private $formFields;
     /** @var ScenarioState|null */
     private $scenarioState;
+    /** @var JsonPathConditionIterator|null */
+    private $jsonPath;
 
     public function __construct(
         ?MethodCondition $method = null,
@@ -46,7 +49,8 @@ class Conditions
         ?BodyCondition $body = null,
         ?HeaderConditionIterator $headers = null,
         ?FormFieldConditionIterator $formFields = null,
-        ?ScenarioState $scenarioState = null
+        ?ScenarioState $scenarioState = null,
+        ?JsonPathConditionIterator $jsonPath = null
     ) {
         $this->method = $method;
         $this->url = $url;
@@ -54,6 +58,7 @@ class Conditions
         $this->headers = $headers;
         $this->formFields = $formFields;
         $this->scenarioState = $scenarioState;
+        $this->jsonPath = $jsonPath;
     }
 
     public function hasMethod(): bool
@@ -114,5 +119,15 @@ class Conditions
     public function getScenarioState(): ?ScenarioState
     {
         return $this->scenarioState;
+    }
+
+    public function hasJsonPath(): bool 
+    {
+        return null !== $this->jsonPath;
+    }
+
+    public function getJsonPath(): ?JsonPathConditionIterator
+    {
+        return $this->jsonPath;
     }
 }

--- a/src/Domain/Http/JsonPathName.php
+++ b/src/Domain/Http/JsonPathName.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mcustiel\Phiremock\Domain\Http;
+
+class JsonPathName
+{
+    /** @var string */
+    private $path;
+
+    public function __construct(string $path)
+    {
+        $this->ensureIsNotEmpty($path); 
+        $this->path = $path;
+    }
+
+    public function asString(): string
+    {
+        return $this->path;
+    }
+
+    private function ensureIsNotEmpty(string $path): void
+    {
+        if ($path === '') {
+            throw new \InvalidArgumentException('JSON path can\'t be empty');
+        }
+    }
+}

--- a/tests/unit/Common/Utils/V2/JsonConvertTest.php
+++ b/tests/unit/Common/Utils/V2/JsonConvertTest.php
@@ -248,7 +248,7 @@ class JsonConvertTest extends TestCase
         "version": "2",
         "on": {
             "jsonPath": {
-                "store.book[0].price": {
+                "store.book.0.price": {
                     "isEqualTo": 10
                 },
                 "store.bicycle.color": {
@@ -274,7 +274,7 @@ class JsonConvertTest extends TestCase
             "headers": null,
             "formData": null,
             "jsonPath": {
-                "store.book[0].price": {
+                "store.book.0.price": {
                     "isEqualTo": 10
                 },
                 "store.bicycle.color": {

--- a/tests/unit/Common/Utils/V2/JsonConvertTest.php
+++ b/tests/unit/Common/Utils/V2/JsonConvertTest.php
@@ -37,7 +37,8 @@ class JsonConvertTest extends TestCase
             "url":null,
             "body": null,
             "headers" : null,
-            "formData": null
+            "formData": null,
+            "jsonPath": null
         },
         "then": {
             "delayMillis": null,
@@ -68,7 +69,8 @@ class JsonConvertTest extends TestCase
             "url":null,
             "body": null,
             "headers" : null,
-            "formData": null
+            "formData": null,
+            "jsonPath": null
         },
         "then": {
             "delayMillis": null,
@@ -103,7 +105,8 @@ class JsonConvertTest extends TestCase
                 "isSameJsonObject": "{\"Tomato\":\"Potat\"}"
             },
             "headers" : null,
-            "formData": null
+            "formData": null,
+            "jsonPath": null
         },
         "then": {
             "delayMillis": null,
@@ -139,7 +142,8 @@ class JsonConvertTest extends TestCase
             "url":null,
             "body": null,
             "headers" : null,
-            "formData": null
+            "formData": null,
+            "jsonPath": null
         },
         "then": {
             "delayMillis": null,
@@ -176,7 +180,12 @@ class JsonConvertTest extends TestCase
     			"name": {
     				"isEqualTo": "potato"
     			}
-    		}
+    		},
+            "jsonPath": {
+                "user.id": {
+                    "isEqualTo": "123"
+                }
+            }
     	},
     	"then": {
             "newScenarioState": "tomato",
@@ -214,7 +223,12 @@ class JsonConvertTest extends TestCase
     			"name": {
     				"isEqualTo": "potato"
     			}
-    		}
+    		},
+            "jsonPath": {
+                "user.id": {
+                    "isEqualTo": "123"
+                }
+            }
     	},
     	"then": {
             "delayMillis": 1000,
@@ -229,6 +243,59 @@ class JsonConvertTest extends TestCase
             }
     	},
         "priority": 3
+    }';
+    private const JSON_PATH_CONDITION = '{
+        "version": "2",
+        "on": {
+            "jsonPath": {
+                "store.book[0].price": {
+                    "isEqualTo": 10
+                },
+                "store.bicycle.color": {
+                    "matches": "/^(red|blue)$/"
+                },
+                "store.basket.items.length": {
+                    "isEqualTo": 3
+                }
+            }
+        },
+        "then": {
+            "response": {"statusCode": 200}
+        }
+    }';
+    private const JSON_PATH_CONDITION_EXPECTED = '{
+        "version": "2",
+        "scenarioName": null,
+        "on": {
+            "scenarioStateIs": null,
+            "method": null,
+            "url": null,
+            "body": null,
+            "headers": null,
+            "formData": null,
+            "jsonPath": {
+                "store.book[0].price": {
+                    "isEqualTo": 10
+                },
+                "store.bicycle.color": {
+                    "matches": "/^(red|blue)$/"
+                },
+                "store.basket.items.length": {
+                    "isEqualTo": 3
+                }
+            }
+        },
+        "then": {
+            "delayMillis": null,
+            "newScenarioState": null,
+            "proxyTo": null,
+            "response": {
+                "statusCode": 200,
+                "body": null,
+                "headers": null
+            }
+        },
+        "priority": 0
     }';
 
     /** @var ArrayToExpectationConverterLocator */
@@ -251,6 +318,7 @@ class JsonConvertTest extends TestCase
             'base config'                => [self::BASIC_CONFIG, self::BASIC_CONFIG_EXPECTED],
             'json body request'          => [self::JSON_CONDITION, self::JSON_CONDITION_EXPECTED],
             'full config'                => [self::FULL_CONFIG, self::FULL_CONFIG_EXPECTED],
+            'json path condition'        => [self::JSON_PATH_CONDITION, self::JSON_PATH_CONDITION_EXPECTED],
         ];
     }
 


### PR DESCRIPTION
Add JSON Path request condition filter

This PR adds a new feature that allows filtering requests by checking values in specific JSON paths of the request body. This is particularly useful when you need to match nested JSON structures in requests.

Changes include:
- Added JsonPathCondition class for handling JSON path request matching
- Updated documentation in README.md with JSON Path feature description and examples
- Added tests to verify JSON path matching behavior

The feature supports all standard matchers (isEqualTo, matches, contains, isSameString) and uses simple dot notation for specifying JSON paths. Use cases include:

```json
{
    "user.address.zipCode": { "isEqualTo": "12345" }
}
```

All tests are passing